### PR TITLE
Current user doesn't need to have an account.

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,31 +4,14 @@ import (
 	"io/fs"
 	"log"
 	"os"
-	"os/user"
 	"path/filepath"
-	"strconv"
 )
 
 var chownDir string
 
 func main() {
-	u, err := user.Current()
-	if err != nil {
-		log.Println(err)
-		return
-	}
-
-	iUid, err := strconv.Atoi(u.Uid)
-	if err != nil {
-		log.Println(err)
-		return
-	}
-
-	iGid, err := strconv.Atoi(u.Gid)
-	if err != nil {
-		log.Println(err)
-		return
-	}
+	uid := os.Getuid()
+	gid := os.Getgid()
 
 	if chownDir == "" {
 		log.Printf("Must be compiled with a valid directory to chown")
@@ -47,8 +30,8 @@ func main() {
 		return
 	}
 
-	log.Printf("Chown %d:%d %s", iUid, iGid, dir)
-	err = ChownR(dir, iUid, iGid)
+	log.Printf("Chown %d:%d %s", uid, gid, dir)
+	err = ChownR(dir, uid, gid)
 	if err != nil {
 		log.Println(err)
 	}


### PR DESCRIPTION
Get the current user's uid and gid directly from the OS, without checking the user database.  Allows permset to work for an arbitrary user that was not known when the container was built.

Starting the example with --user 4000:4000, and running permset, results in an error

    "user: unknown userid 4000"

I was having issues in jacobalberty/unifi, with this exact case, which I needed to match some nfs squashing on a mounted volume.  The existing permset would fail and the container continued with errors that made it unusable.